### PR TITLE
Typos in English index.html

### DIFF
--- a/e/index.html
+++ b/e/index.html
@@ -382,7 +382,7 @@
 	</section>
 
 	<section id="effect">
-		<h1><span>The effects</span></h1>
+		<h1><span>Effects</span></h1>
 		<p>By using the plug-in effect SDK, the effects developed by Dwango's machine leaning research and development team are released. They include the effect of automatically changing picture styles by applying the deep learning technology and the effect of producing affected incident light like those in classic works before the digitization of the production environment.</p>
 		<div class="contents clearfix">
 			<div class="effect01 card">
@@ -401,7 +401,7 @@
 	</section>
 
 	<section id="function">
-		<h1><span>Introducte the functions</span></h1>
+		<h1><span>Functions</span></h1>
 		<div class="inner">
 			<div class="slider contents clearfix">
 				<ul class="slides">


### PR DESCRIPTION
I don't believe "Introducte the functions" is the intended heading. It's simpler to just say "Functions".