### PR TITLE
Add link to the commit history

### DIFF
--- a/download/opentoonz.html
+++ b/download/opentoonz.html
@@ -118,7 +118,9 @@ OpenToonzの利用に起因又は関連して利用者に生じた損害、権�
                     <label>※Windows版ご利用の方へ※ Intel Graphicsドライバーのいくつかのバージョンで、OpenToonzのGUIが異常に拡大して表示されてしまう不具合が確認されています。最新のドライバー（26.20.100.7584以降）では不具合が解消しています。Windows Updateで見つからない場合は<a href="https://www.intel.co.jp/content/www/jp/ja/support/detect.html">Intel社のWebサイト</a>から最新のドライバーをインストールすることができます。</label>
                 </div>
                 <div class="rcnotearea">
-                    <label>ナイトリービルド版は開発プロジェクトの最新のソースコードを用いて毎日更新されるもので、最新の機能やバグ修正を試すことができます。</label>
+                    <label>ナイトリービルド版は開発プロジェクトの最新のソースコードを用いて毎日更新されるもので、最新の機能やバグ修正を試すことができます。
+                        更新履歴は<a href="https://github.com/opentoonz/opentoonz/commits/nightly">こちら</a>をご参照ください。
+                    </label>
                 </div>
                 <div class="nightly">
                     <div class="downloadarea">

--- a/e/download/opentoonz.html
+++ b/e/download/opentoonz.html
@@ -122,7 +122,8 @@ Revised on December 24, 2019
                     <label>For Windows users: There is a known issue that OpenToonz GUI irregulary scales when used on PC with some version of Intel Graphics Driver. Installing the latest driver (26.20.100.7584 and newer) will resolve the problem. If it is not yet listed in Windows Update, please try updating via <a href="https://www.intel.com/content/www/us/en/support/detect.html">Intel's website.</a></label>
                 </div>
                 <div class="rcnotearea">
-                    <label>Nightly Build version is a build of the latest version of source code, updated on a daily basis. It is for testing and exploring the most current bug fixes and features.</label>
+                    <label>Nightly Build version is a build of the latest version of source code, updated on a daily basis. It is for testing and exploring the most current bug fixes and features.
+                        You can browse the change history <a href="https://github.com/opentoonz/opentoonz/commits/nightly">here</a>.</label>
                 </div>
                 <div class="nightly">
                     <div class="downloadarea">

--- a/es/download/opentoonz.html
+++ b/es/download/opentoonz.html
@@ -122,7 +122,8 @@ Revised on December 24, 2019
                     <label>For Windows users: There is a known issue that OpenToonz GUI irregulary scales when used on PC with some version of Intel Graphics Driver. Installing the latest driver (26.20.100.7584 and newer) will resolve the problem. If it is not yet listed in Windows Update, please try updating via <a href="https://www.intel.com/content/www/us/en/support/detect.html">Intel's website.</a></label>
                 </div>
                 <div class="rcnotearea">
-                    <label>Nightly Build version is a build of the latest version of source code, updated on a daily basis. It is for testing and exploring the most current bug fixes and features.</label>
+                    <label>Nightly Build version is a build of the latest version of source code, updated on a daily basis. It is for testing and exploring the most current bug fixes and features.
+                        You can browse the change history <a href="https://github.com/opentoonz/opentoonz/commits/nightly">here</a>.</label>
                 </div>
                 <div class="nightly">
                     <div class="downloadarea">

--- a/fa/download/opentoonz.html
+++ b/fa/download/opentoonz.html
@@ -121,7 +121,8 @@ Revised on December 24, 2019
                     <label>برای کاربران ویندوز: یک مسئله شناخته شده وجود دارد که رابط کاربری گرافیکی اوپن تونز هنگام استفاده روی کامپیوتری با برخی از نسخه های درایور گرافیک اینتل به طور نامنظمی مقیاس بندی می شود. نصب جدید ترین درایور (۲۶.۲۰.۱۰۰.۷۵۸۴ و جدید تر) مشکل را برطرف می کند. اگر هنوز در آپدیت ویندوز لیست نشده است، لطفا از طریق <a href="https://www.intel.com/content/www/us/en/support/detect.html">وب سایت اینتل</a> بروزرسانی کنید. </label>
                 </div>
                 <div class="rcnotearea">
-                    <label>نسخه Nightly Build یک Build از آخرین نسخه کد منبع است، که به صورت روزانه بروزرسانی می شود. این نسخه برای تست و وارسی فعلی ترین رفع اشکال ها و ویژگی ها می باشد.</label>
+                    <label>نسخه Nightly Build یک Build از آخرین نسخه کد منبع است، که به صورت روزانه بروزرسانی می شود. این نسخه برای تست و وارسی فعلی ترین رفع اشکال ها و ویژگی ها می باشد.
+                        You can browse the change history <a href="https://github.com/opentoonz/opentoonz/commits/nightly">here</a>.</label>
                 </div>
                 <div class="nightly">
                     <div class="downloadarea">


### PR DESCRIPTION
This PR will add a link to the commit history of the nightly build (https://github.com/opentoonz/opentoonz/commits/nightly) , which was requested in [the comment](https://github.com/opentoonz/opentoonz.github.io/pull/71#issuecomment-824785991) .