### PR TITLE
v1.6.0rc

### DIFF
--- a/download/opentoonz.html
+++ b/download/opentoonz.html
@@ -111,12 +111,19 @@ OpenToonzの利用に起因又は関連して利用者に生じた損害、権�
                       <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.5.0/OpenToonz.pkg">for macOS<br>安定版 v1.5</a>
                     </span>
                 </div>
-                <div class="warningbox">
-                    <label>OpenToonz v1.4以前のバージョンがインストールされている場合、V1.5をインストールする前に、必ず以前のバージョンのアンインストールを行ってください。</label>
+                
+                <div class="rcnotearea">
+                    <label>リリース候補版は次の安定版リリースの前にユーザーに試用していただくためのもので、最新の機能、バグ修正を含みます。多くの場合安定して動作しますが、重大な不具合を発見した場合にはユーザーコミュニティの掲示板又はGitHubのIssuesに報告をしていただきますようお願いいたします。</label>
                 </div>
-                <div class="warningbox">
-                    <label>※Windows版ご利用の方へ※ Intel Graphicsドライバーのいくつかのバージョンで、OpenToonzのGUIが異常に拡大して表示されてしまう不具合が確認されています。最新のドライバー（26.20.100.7584以降）では不具合が解消しています。Windows Updateで見つからない場合は<a href="https://www.intel.co.jp/content/www/jp/ja/support/detect.html">Intel社のWebサイト</a>から最新のドライバーをインストールすることができます。</label>
+                <div class="downloadarea">
+                    <span class="button win">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.6.0rc/OpenToonzSetup.exe">Windows版<br>リリース候補版 v1.6RC</a>
+                    </span>
+                    <span class="button mac">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.6.0rc/OpenToonz.pkg">macOS版<br>リリース候補版 v1.6RC</a>
+                    </span>
                 </div>
+                <!-- nightly build area is temporary hidden during the RC period
                 <div class="rcnotearea">
                     <label>ナイトリービルド版は開発プロジェクトの最新のソースコードを用いて毎日更新されるもので、最新の機能やバグ修正を試すことができます。
                         更新履歴は<a href="https://github.com/opentoonz/opentoonz/commits/nightly">こちら</a>をご参照ください。
@@ -132,6 +139,7 @@ OpenToonzの利用に起因又は関連して利用者に生じた損害、権�
                         </span>
                     </div>
                 </div>
+                -->
                 <div class="returnarea">
                     <div class="button">
                         <a href="../index.html"> OpenToonz サイトに戻る</a>

--- a/e/download/opentoonz.html
+++ b/e/download/opentoonz.html
@@ -115,12 +115,20 @@ Revised on December 24, 2019
                   <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.5.0/OpenToonz.pkg">Download for macOS<br>v1.5</a>
                 </span>
                 </div>
-                <div class="warningarea">
-                    <label>Please make sure to uninstall all the previous versions of OpenToonz before installing V1.5.</label>
+
+                <div class="rcnotearea">
+                    <label>The Release Candidate (RC) versions are for testing the latest version of software before next stable release. It contains more features and bug fixes and will work more stable in most cases. If you find any critical problem, please report it in the user forum or in GitHub issues.</label>
                 </div>
-                <div class="warningarea">
-                    <label>For Windows users: There is a known issue that OpenToonz GUI irregulary scales when used on PC with some version of Intel Graphics Driver. Installing the latest driver (26.20.100.7584 and newer) will resolve the problem. If it is not yet listed in Windows Update, please try updating via <a href="https://www.intel.com/content/www/us/en/support/detect.html">Intel's website.</a></label>
+                <div class="downloadarea">
+                    <span class="button win">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.6.0rc/OpenToonzSetup.exe">Download for Windows<br>v1.6RC</a>
+                    </span>
+                    <span class="button mac">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.6.0rc/OpenToonz.pkg">Download for macOS<br>v1.6RC</a>
+                    </span>
                 </div>
+
+                <!-- nightly build area is temporary hidden during the RC period
                 <div class="rcnotearea">
                     <label>Nightly Build version is a build of the latest version of source code, updated on a daily basis. It is for testing and exploring the most current bug fixes and features.
                         You can browse the change history <a href="https://github.com/opentoonz/opentoonz/commits/nightly">here</a>.</label>
@@ -135,6 +143,7 @@ Revised on December 24, 2019
                         </span>
                     </div>
                 </div>
+                -->
                 <div class="returnarea">
                     <div class="button">
                         <a href="../index.html"> Back to Homepage</a>

--- a/es/download/opentoonz.html
+++ b/es/download/opentoonz.html
@@ -115,12 +115,20 @@ Revised on December 24, 2019
                   <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.5.0/OpenToonz.pkg">Descargar para macOS<br>v1.5</a>
                 </span>
                 </div>
-                <div class="warningarea">
-                    <label>Asegurarse de desinstalar todas las versiones anteriores de OpenToonz previo a instalar la V1.5.</label>
+
+                <div class="rcnotearea">
+                    <label>The Release Candidate (RC) versions are for testing the latest version of software before next stable release. It contains more features and bug fixes and will work more stable in most cases. If you find any critical problem, please report it in the user forum or in GitHub issues.</label>
                 </div>
-                <div class="warningarea">
-                    <label>For Windows users: There is a known issue that OpenToonz GUI irregulary scales when used on PC with some version of Intel Graphics Driver. Installing the latest driver (26.20.100.7584 and newer) will resolve the problem. If it is not yet listed in Windows Update, please try updating via <a href="https://www.intel.com/content/www/us/en/support/detect.html">Intel's website.</a></label>
+                <div class="downloadarea">
+                    <span class="button win">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.6.0rc/OpenToonzSetup.exe">Download for Windows<br>v1.6RC</a>
+                    </span>
+                    <span class="button mac">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.6.0rc/OpenToonz.pkg">Download for macOS<br>v1.6RC</a>
+                    </span>
                 </div>
+
+                <!-- nightly build area is temporary hidden during the RC period
                 <div class="rcnotearea">
                     <label>Nightly Build version is a build of the latest version of source code, updated on a daily basis. It is for testing and exploring the most current bug fixes and features.
                         You can browse the change history <a href="https://github.com/opentoonz/opentoonz/commits/nightly">here</a>.</label>
@@ -135,6 +143,7 @@ Revised on December 24, 2019
                         </span>
                     </div>
                 </div>
+                -->
                 <div class="returnarea">
                     <div class="button">
                         <a href="../index.html"> Regresar a la página de inicio</a>

--- a/fa/download/opentoonz.html
+++ b/fa/download/opentoonz.html
@@ -114,12 +114,20 @@ Revised on December 24, 2019
                         <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.5.0/OpenToonz.pkg">دانلود برای مک او اس<br>نسخه ۱.۵</a>
                     </span>
                 </div>
-                <div class="warningarea">
-                    <label>برای کاربران مک او اس: لطفا مطمئن بشید که قبل از نصب نسخه ۱.۵ برای مک او اس تمام نسخه های قبلی اوپن تونز را حذف کردید.</label>
+
+                <div class="rcnotearea">
+                    <label>The Release Candidate (RC) versions are for testing the latest version of software before next stable release. It contains more features and bug fixes and will work more stable in most cases. If you find any critical problem, please report it in the user forum or in GitHub issues.</label>
                 </div>
-                <div class="warningarea">
-                    <label>برای کاربران ویندوز: یک مسئله شناخته شده وجود دارد که رابط کاربری گرافیکی اوپن تونز هنگام استفاده روی کامپیوتری با برخی از نسخه های درایور گرافیک اینتل به طور نامنظمی مقیاس بندی می شود. نصب جدید ترین درایور (۲۶.۲۰.۱۰۰.۷۵۸۴ و جدید تر) مشکل را برطرف می کند. اگر هنوز در آپدیت ویندوز لیست نشده است، لطفا از طریق <a href="https://www.intel.com/content/www/us/en/support/detect.html">وب سایت اینتل</a> بروزرسانی کنید. </label>
+                <div class="downloadarea">
+                    <span class="button win">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.6.0rc/OpenToonzSetup.exe">Download for Windows<br>v1.6RC</a>
+                    </span>
+                    <span class="button mac">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.6.0rc/OpenToonz.pkg">Download for macOS<br>v1.6RC</a>
+                    </span>
                 </div>
+
+                <!-- nightly build area is temporary hidden during the RC period
                 <div class="rcnotearea">
                     <label>نسخه Nightly Build یک Build از آخرین نسخه کد منبع است، که به صورت روزانه بروزرسانی می شود. این نسخه برای تست و وارسی فعلی ترین رفع اشکال ها و ویژگی ها می باشد.
                         You can browse the change history <a href="https://github.com/opentoonz/opentoonz/commits/nightly">here</a>.</label>
@@ -134,6 +142,7 @@ Revised on December 24, 2019
                         </span>
                     </div>
                 </div>
+                -->
                 <div class="returnarea">
                     <div class="button"><a href="../index.html">برگشت به صفحه اصلی</a></div>
                 </div>


### PR DESCRIPTION
This PR will add download buttons for V1.6.0RC.

- Temporary hid the buttons for nightly build version since it will be almost identical to the RC version.
- Removed the warning for clean-installing since v1.6 uses the same version of Qt libraries as v1.5.
- Also removed the warning for updating Intel driver since the months passed.