### PR TITLE
v1.7.0RC

### DIFF
--- a/download/opentoonz.html
+++ b/download/opentoonz.html
@@ -113,6 +113,18 @@ OpenToonzの利用に起因又は関連して利用者に生じた損害、権�
                 </div>
                 
                 <div class="rcnotearea">
+                    <label>リリース候補版は次の安定版リリースの前にユーザーに試用していただくためのもので、最新の機能、バグ修正を含みます。多くの場合安定して動作しますが、重大な不具合を発見した場合にはユーザーコミュニティの掲示板又はGitHubのIssuesに報告をしていただきますようお願いいたします。</label>
+                </div>
+                <div class="downloadarea">
+                    <span class="button win">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.7.0rc/OpenToonzSetup.exe">for Windows<br>リリース候補版 v1.7RC</a>
+                    </span>
+                    <span class="button mac">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.7.0rc/OpenToonz.pkg">for macOS<br>リリース候補版 v1.7RC</a>
+                    </span>
+                </div>
+                <!-- nightly build area is temporary hidden during the RC period
+                <div class="rcnotearea">
                     <label>ナイトリービルド版は開発プロジェクトの最新のソースコードを用いて毎日更新されるもので、最新の機能やバグ修正を試すことができます。
                         更新履歴は<a href="https://github.com/opentoonz/opentoonz/commits/nightly">こちら</a>をご参照ください。
                     </label>
@@ -127,6 +139,7 @@ OpenToonzの利用に起因又は関連して利用者に生じた損害、権�
                         </span>
                     </div>
                 </div>
+                -->
                 
                 <div class="returnarea">
                     <div class="button">

--- a/e/download/opentoonz.html
+++ b/e/download/opentoonz.html
@@ -117,6 +117,19 @@ Revised on December 24, 2019
                 </div>
 
                 <div class="rcnotearea">
+                    <label>The Release Candidate (RC) versions are for testing the latest version of software before next stable release. It contains more features and bug fixes and will work more stable in most cases. If you find any critical problem, please report it in the user forum or in GitHub issues.</label>
+                </div>
+                <div class="downloadarea">
+                    <span class="button win">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.7.0rc/OpenToonzSetup.exe">Download for Windows<br>v1.7RC</a>
+                    </span>
+                    <span class="button mac">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.7.0rc/OpenToonz.pkg">Download for macOS<br>v1.7RC</a>
+                    </span>
+                </div>
+
+                <!-- nightly build area is temporary hidden during the RC period
+                <div class="rcnotearea">
                     <label>Nightly Build version is a build of the latest version of source code, updated on a daily basis. It is for testing and exploring the most current bug fixes and features.
                         You can browse the change history <a href="https://github.com/opentoonz/opentoonz/commits/nightly">here</a>.</label>
                 </div>
@@ -130,6 +143,7 @@ Revised on December 24, 2019
                         </span>
                     </div>
                 </div>
+                -->
                 
                 <div class="returnarea">
                     <div class="button">

--- a/es/download/opentoonz.html
+++ b/es/download/opentoonz.html
@@ -117,6 +117,19 @@ Revised on December 24, 2019
                 </div>
 
                 <div class="rcnotearea">
+                    <label>The Release Candidate (RC) versions are for testing the latest version of software before next stable release. It contains more features and bug fixes and will work more stable in most cases. If you find any critical problem, please report it in the user forum or in GitHub issues.</label>
+                </div>
+                <div class="downloadarea">
+                    <span class="button win">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.7.0rc/OpenToonzSetup.exe">Download for Windows<br>v1.7RC</a>
+                    </span>
+                    <span class="button mac">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.7.0rc/OpenToonz.pkg">Download for macOS<br>v1.7RC</a>
+                    </span>
+                </div>
+
+                <!-- nightly build area is temporary hidden during the RC period
+                <div class="rcnotearea">
                     <label>Nightly Build version is a build of the latest version of source code, updated on a daily basis. It is for testing and exploring the most current bug fixes and features.
                         You can browse the change history <a href="https://github.com/opentoonz/opentoonz/commits/nightly">here</a>.</label>
                 </div>
@@ -129,7 +142,8 @@ Revised on December 24, 2019
                         <a href="https://github.com/opentoonz/opentoonz/releases/download/nightly/OpenToonz.pkg">Download Nightly Build for macOS</a>
                         </span>
                     </div>
-                </div>
+                </div>                
+                -->
                 
                 <div class="returnarea">
                     <div class="button">

--- a/fa/download/opentoonz.html
+++ b/fa/download/opentoonz.html
@@ -116,6 +116,19 @@ Revised on December 24, 2019
                 </div>
 
                 <div class="rcnotearea">
+                    <label>The Release Candidate (RC) versions are for testing the latest version of software before next stable release. It contains more features and bug fixes and will work more stable in most cases. If you find any critical problem, please report it in the user forum or in GitHub issues.</label>
+                </div>
+                <div class="downloadarea">
+                    <span class="button win">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.7.0rc/OpenToonzSetup.exe">Download for Windows<br>v1.7RC</a>
+                    </span>
+                    <span class="button mac">
+                      <a href="https://github.com/opentoonz/opentoonz/releases/download/v1.7.0rc/OpenToonz.pkg">Download for macOS<br>v1.7RC</a>
+                    </span>
+                </div>
+
+                <!-- nightly build area is temporary hidden during the RC period
+                <div class="rcnotearea">
                     <label>نسخه Nightly Build یک Build از آخرین نسخه کد منبع است، که به صورت روزانه بروزرسانی می شود. این نسخه برای تست و وارسی فعلی ترین رفع اشکال ها و ویژگی ها می باشد.
                         You can browse the change history <a href="https://github.com/opentoonz/opentoonz/commits/nightly">here</a>.</label>
                 </div>
@@ -129,6 +142,7 @@ Revised on December 24, 2019
                         </span>
                     </div>
                 </div>
+                -->
                 
                 <div class="returnarea">
                     <div class="button"><a href="../index.html">برگشت به صفحه اصلی</a></div>


### PR DESCRIPTION
[To be merged when V1.7RC is released]
This PR will add download buttons for V1.7.0RC.
Temporary hid the buttons for nightly build version since it will be almost identical to the RC version.